### PR TITLE
Rename to `Food and Drink`

### DIFF
--- a/Spells/Mainline.lua
+++ b/Spells/Mainline.lua
@@ -161,7 +161,7 @@ BuffOverlay.defaultSpells = {
 
     -- Misc
     [L["Eating/Drinking"]] = { class = "MISC", prio = 90 },      --Food umbrella
-        [L["Food & Drink"]] = { parent = L["Eating/Drinking"] }, --Food & Drink
+        [L["Food and Drink"]] = { parent = L["Eating/Drinking"] }, --Food and Drink
         [L["Food"]] = { parent = L["Eating/Drinking"] },         --Food
         [L["Drink"]] = { parent = L["Eating/Drinking"] },        --Drink
         [L["Refreshment"]] = { parent = L["Eating/Drinking"] },  --Refreshment

--- a/Spells/Mainline.lua
+++ b/Spells/Mainline.lua
@@ -160,12 +160,12 @@ BuffOverlay.defaultSpells = {
     [58984] = { class = "MISC", prio = 70 }, --Shadowmeld
 
     -- Misc
-    [L["Eating/Drinking"]] = { class = "MISC", prio = 90 },      --Food umbrella
+    [L["Eating/Drinking"]] = { class = "MISC", prio = 90 },        --Food umbrella
         [L["Food and Drink"]] = { parent = L["Eating/Drinking"] }, --Food and Drink
-        [L["Food"]] = { parent = L["Eating/Drinking"] },         --Food
-        [L["Drink"]] = { parent = L["Eating/Drinking"] },        --Drink
-        [L["Refreshment"]] = { parent = L["Eating/Drinking"] },  --Refreshment
-        [185710] = { parent = L["Eating/Drinking"] },            --Sugar-Crusted Fish Feast
+        [L["Food"]] = { parent = L["Eating/Drinking"] },           --Food
+        [L["Drink"]] = { parent = L["Eating/Drinking"] },          --Drink
+        [L["Refreshment"]] = { parent = L["Eating/Drinking"] },    --Refreshment
+        [185710] = { parent = L["Eating/Drinking"] },              --Sugar-Crusted Fish Feast
         [L["NewFood"]] = L["NewFood"] ~= "Remove" and { parent = L["Eating/Drinking"] } or nil,
         [L["NewDrink"]] = L["NewDrink"] ~= "Remove" and { parent = L["Eating/Drinking"] } or nil,
     [320224] = { class = "MISC", prio = 70 }, -- Podtender

--- a/Spells/Mainline.lua
+++ b/Spells/Mainline.lua
@@ -161,6 +161,7 @@ BuffOverlay.defaultSpells = {
 
     -- Misc
     [L["Eating/Drinking"]] = { class = "MISC", prio = 90 },        --Food umbrella
+        [L["Food & Drink"]] = { parent = L["Eating/Drinking"] },   --Food & Drink
         [L["Food and Drink"]] = { parent = L["Eating/Drinking"] }, --Food and Drink
         [L["Food"]] = { parent = L["Eating/Drinking"] },           --Food
         [L["Drink"]] = { parent = L["Eating/Drinking"] },          --Drink


### PR DESCRIPTION
Renamed `Food & Drink` to `Food and Drink`
https://www.wowhead.com/spell=462177/food-and-drink

Tested with [[Feast of the Midnight Masquerade]](https://www.wowhead.com/item=222733/feast-of-the-midnight-masquerade) and [[Beledar's Bounty]](https://www.wowhead.com/item=222728/beledars-bounty)